### PR TITLE
Fix deps - repos removed from dreid's github public repos

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,9 +2,9 @@
 {deps, [{meck, ".*",
          {git, "git://github.com/esl/meck.git", "master"}},
         {amqp_client, ".*",
-         {git, "git://github.com/dreid/amqp_client.git", "master"}},
+         {git, "git://github.com/mochi/amqp_client.git", "master"}},
         {rabbit_common, ".*",
-         {git, "git://github.com/dreid/rabbit_common.git", "master"}}]}.
+         {git, "git://github.com/mochi/rabbit_common.git", "master"}}]}.
 {cover_enabled, true}.
 {erl_opts, [debug_info]}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.


### PR DESCRIPTION
Update dependencies to point to mochi's repos as dreid's appear to have been removed.
