### PR TITLE
Update rebar.config (change meck to eproxus repo)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 % -*- mode: erlang -*-
 {deps, [{meck, ".*",
-         {git, "git://github.com/esl/meck.git", "master"}},
+         {git, "git://github.com/eproxus/meck.git", "master"}},
         {amqp_client, ".*",
          {git, "git://github.com/mochi/amqp_client.git", "master"}},
         {rabbit_common, ".*",


### PR DESCRIPTION
change meck to eproxus repo (the esl repo still uses dict/0 which is deprecated, and thus compile fails when using erlang.mk).
